### PR TITLE
Add simple logging and viewer for webapp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ log
 prompts
 __pycache__
 tmp
+webapp/logs.jsonl

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,12 +1,42 @@
 from flask import Flask, render_template, request, jsonify
 import re
+import json
+import os
+from datetime import datetime
+import uuid
 import remove  # 同フォルダの既存クリーナーを利用
 
 app = Flask(__name__)
 
+LOG_FILE = os.path.join(os.path.dirname(__file__), "logs.jsonl")
+
+
+def append_log(entry: dict) -> None:
+    os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+    with open(LOG_FILE, "a", encoding="utf-8") as f:
+        json.dump(entry, f, ensure_ascii=False)
+        f.write("\n")
+
+
+def read_logs() -> list:
+    if not os.path.exists(LOG_FILE):
+        return []
+    logs = []
+    with open(LOG_FILE, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                try:
+                    logs.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    return logs
+
+
 @app.route("/")
 def index():
     return render_template("index.html")
+
 
 @app.route("/clean", methods=["POST"])
 def clean():
@@ -26,7 +56,23 @@ def clean():
     company = remove.detect_company(raw)
     hashtags = remove.build_hashtags(company)
 
+    entry = {
+        "id": str(uuid.uuid4()),
+        "timestamp": datetime.now().isoformat(timespec="seconds"),
+        "input": raw,
+        "title": title,
+        "body": body,
+        "hashtags": hashtags,
+    }
+    append_log(entry)
+
     return jsonify({"title": title, "body": body, "hashtags": hashtags})
+
+
+@app.route("/logs", methods=["GET"])
+def logs():
+    return jsonify(read_logs())
+
 
 if __name__ == "__main__":
     app.run(debug=True, host="0.0.0.0", port=5005)

--- a/webapp/static/main.js
+++ b/webapp/static/main.js
@@ -1,6 +1,27 @@
 // エラー・出力要素
 const errMsg = document.getElementById("err");
 const output = document.getElementById("output");
+const logSelect = document.getElementById("logSelect");
+let logsData = [];
+
+async function loadLogs() {
+  const resp = await fetch("/logs");
+  if (!resp.ok) return;
+  logsData = await resp.json();
+  logSelect.innerHTML = "";
+  const placeholder = document.createElement("option");
+  placeholder.textContent = "--ログを選択--";
+  placeholder.value = "";
+  logSelect.appendChild(placeholder);
+  logsData.forEach((log) => {
+    const opt = document.createElement("option");
+    opt.value = log.id;
+    opt.textContent = `${log.timestamp} ${log.title}`;
+    logSelect.appendChild(opt);
+  });
+}
+
+document.addEventListener("DOMContentLoaded", loadLogs);
 
 document.getElementById("run").addEventListener("click", async () => {
   const md = document.getElementById("input").value.trim();
@@ -24,6 +45,7 @@ document.getElementById("run").addEventListener("click", async () => {
   document.getElementById("body").value     = data.body;
   document.getElementById("hashtags").value = data.hashtags;
   output.classList.remove("hidden");
+  loadLogs();
 });
 
 // クリップボード
@@ -37,5 +59,15 @@ document.addEventListener("click", async (e) => {
     setTimeout(() => (e.target.textContent = "コピー"), 1000);
   } catch {
     alert("コピーに失敗しました");
+  }
+});
+
+logSelect.addEventListener("change", () => {
+  const log = logsData.find((l) => l.id === logSelect.value);
+  if (log) {
+    document.getElementById("title").value = log.title;
+    document.getElementById("body").value = log.body;
+    document.getElementById("hashtags").value = log.hashtags;
+    output.classList.remove("hidden");
   }
 });

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -61,6 +61,12 @@
     </div>
   </section>
 
+  <!-- ログ一覧 -->
+  <section class="w-full max-w-5xl flex flex-col gap-2" id="log-area">
+    <h2 class="font-semibold">過去ログ</h2>
+    <select id="logSelect" class="p-2 rounded border max-w-full"></select>
+  </section>
+
   <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- log each clean action to `logs.jsonl`
- expose `/logs` endpoint returning all logs
- show past logs in a dropdown on the UI
- allow selecting a log to re-display output
- ignore generated `logs.jsonl`

## Testing
- `black webapp/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e5ee5c5688333ac20d2d42dda0878